### PR TITLE
Added fullscreen functionality.

### DIFF
--- a/css/px-video.css
+++ b/css/px-video.css
@@ -132,12 +132,39 @@
 	background-position: -13px -225px;
 }
 
+.px-video-fullscreen-btn-container label {
+	display: inline-block;
+	width: 25px;
+	height: 20px;
+	margin-left: 10px;
+	background: no-repeat url('../images/px-video-sprite.png');
+	background-position: -6px -907px;
+}
+.px-video-fullscreen-btn-container input[type="checkbox"]:focus+label {
+	outline: 1px #999 dotted;
+	background-position: -6px -943px;
+}
+.px-video-fullscreen-btn-container input[type="checkbox"]:hover+label {
+	background-position: -6px -943px;
+	cursor: pointer;
+}
+.px-video-fullscreen-btn-container input[type="checkbox"]:focus+label {
+	outline: 1px #999 dotted;
+	background-position: -6px -943px;
+}
+.px-video-fullscreen-btn-container input[type="checkbox"]:checked+label {
+	background-position: -6px -979px;
+}
+.px-video-fullscreen-btn-container input[type="checkbox"]:checked:hover+label {
+	background-position: -6px -1015px;
+}
+
 /* captions button */
 .px-video-captions-btn-container label {
 	display: inline-block;
 	width: 25px;
 	height: 20px;
-	margin-left: 25px;
+	margin-left: 10px;
 	background: no-repeat url('../images/px-video-sprite.png');
 	background-position: -6px -835px;
 }
@@ -231,4 +258,30 @@
 		padding: 8px;
 		min-height: 36px;
 	}
+}
+
+.px-video-container.fullscreen {
+	position: fixed;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	-webkit-cursor-visibility: auto-hide;	
+}
+
+/* Fullscreen styles */
+
+/* style applied through js */
+.px-video-controls.js-fullscreen-controls {
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	z-index: 940;
+	background: white;
+}
+
+.px-video-captions.js-fullscreen-captions {
+	min-height: 3.5em;
+	font-size: 2.5em;
+	padding: 1em;
 }


### PR DESCRIPTION
Added fullscreen functionality addressing issue #6. I made it so that it will utilize the same video controls (note the styling may need to be tweaked on these) and it also blows up the captions to make them bigger. I didn't have a fullscreen icon to add so I simply reused the captions icon in place of it. If someone could add a new icon to the spritesheet and then update the styles, that would be great :) 

I made it so that you can also press Enter to go into fullscreen mode (this you can probably remove if you wish). Also I was required to set a keyup event on the Esc because for some reason the Fullscreen API doesn't let you e.preventDefault() so it wouldn't let me revert styles when hitting Esc unless I did that.

More information on Fullscreen API can be found here:
<a href="https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Using_full_screen_mode" target="_blank">https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Using_full_screen_mode</a>

Please note the Fullscreen API is not supported in IE 10 and lower. 

This hasn't been fully tested in all browsers. Let me know if there's anything else I can help with! Thanks a lot for the awesome video player!