### PR TITLE
Fixing manual captioning to work with UNIX and Windows

### DIFF
--- a/js/px-video.js
+++ b/js/px-video.js
@@ -696,11 +696,11 @@ function InitPxVideo(options) {
 							var records = [],
 								record,
 								req = xhr.responseText;
-							records = req.split('\n\n');
+							records = req.split(/\r?\n\r?\n/);
 							for (var r=0; r < records.length; r++) {
 								record = records[r];
 								obj.captions[r] = [];
-								obj.captions[r] = record.split('\n');
+								obj.captions[r] = record.split(/\r\n?|\n/);
 							}
 							// Remove first element ("VTT")
 							obj.captions.shift();


### PR DESCRIPTION
This would address Issue #80 - manual closed captioning did not work with caption files written on Windows systems, since it tried to split the caption files at /n, instead of /r/n.

This update would split the caption files at either /n OR /r/n, so caption files from UNIX and Windows systems would be work.