### PR TITLE
Prefix progress-bar with `px-` to avoid style clashes

### DIFF
--- a/css/px-video.css
+++ b/css/px-video.css
@@ -72,21 +72,21 @@
   width: 100%;
   height: 100%;
 }
-.progress-bar {
+.px-progress-bar {
   width: 85%;
 }
 @media only screen and (min-width: 480px) {
-  .progress-bar {
+  .px-progress-bar {
     width: 89%;
   }
 }
 @media only screen and (min-width: 970px) {
-  .progress-bar {
+  .px-progress-bar {
     width: 95%;
   }
 }
 @media only screen and (min-width: 1795px) {
-  .progress-bar {
+  .px-progress-bar {
     width: 97.5%;
   }
 }
@@ -112,7 +112,7 @@
   -webkit-appearance: none;
   border: none;
 }
-.px-video-progress[value]::-webkit-progress-bar {
+.px-video-progress[value]::-webkit-px-progress-bar {
   background-color: #e6e6e6;
 }
 .px-video-progress[value]::-webkit-progress-value {
@@ -454,27 +454,27 @@
   align-items: center;
   align-content: center;
 }
-.progress-bar {
+.px-progress-bar {
   flex-grow: 1;
   width: 75%;
 }
 @media only screen and (min-width: 480px) {
-  .progress-bar {
+  .px-progress-bar {
     width: 75%;
   }
 }
 @media only screen and (min-width: 590px) {
-  .progress-bar {
+  .px-progress-bar {
     width: 85%;
   }
 }
 @media only screen and (min-width: 970px) {
-  .progress-bar {
+  .px-progress-bar {
     width: 85%;
   }
 }
 @media only screen and (min-width: 1795px) {
-  .progress-bar {
+  .px-progress-bar {
     width: 85%;
   }
 }

--- a/css/px-video.css
+++ b/css/px-video.css
@@ -112,7 +112,7 @@
   -webkit-appearance: none;
   border: none;
 }
-.px-video-progress[value]::-webkit-px-progress-bar {
+.px-video-progress[value]::-webkit-progress-bar {
   background-color: #e6e6e6;
 }
 .px-video-progress[value]::-webkit-progress-value {

--- a/js/px-video.js
+++ b/js/px-video.js
@@ -207,7 +207,7 @@ function InitPxVideo(options) {
   if (options.debug) {
     console.log("Inserting custom video controls");
   }
-  obj.controls.innerHTML = '<div class="progress-bar">' +
+  obj.controls.innerHTML = '<div class="px-progress-bar">' +
     '<progress class="px-video-progress" max="100" value="0"><span>0</span>% played</progress>' +
     '</div>' +
     '<div class="px-video-time">' +


### PR DESCRIPTION
This also bring the progress bar in-line from a naming perspective with all of the other controls.